### PR TITLE
Cache static Google map images on disk and simplify WebView integration

### DIFF
--- a/ShellfireVPN/src/main/java/de/shellfire/vpn/gui/StaticMapImageCacheManager.java
+++ b/ShellfireVPN/src/main/java/de/shellfire/vpn/gui/StaticMapImageCacheManager.java
@@ -1,0 +1,92 @@
+package de.shellfire.vpn.gui;
+
+import java.io.File;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import org.slf4j.Logger;
+
+import de.shellfire.vpn.Util;
+
+public class StaticMapImageCacheManager {
+	private static final Logger log = Util.getLogger(StaticMapImageCacheManager.class.getCanonicalName());
+	private static final String CACHE_PREFIX = "map_";
+	private static final String CACHE_EXTENSION = ".png";
+	private static final String CACHE_DIR_NAME = "servers\\";
+	private static final int CONNECT_TIMEOUT_MS = 5000;
+	private static final int READ_TIMEOUT_MS = 10000;
+
+	public static String getCachedMapImageUrl(String remoteUrl) {
+		if (remoteUrl == null || remoteUrl.isEmpty()) {
+			return remoteUrl;
+		}
+
+		File cacheDir = getCacheDir();
+		String filename = CACHE_PREFIX + hashUrl(remoteUrl) + CACHE_EXTENSION;
+		File cachedFile = new File(cacheDir, filename);
+
+		if (!cachedFile.exists() || cachedFile.length() == 0) {
+			boolean downloaded = downloadToFile(remoteUrl, cachedFile);
+			if (!downloaded) {
+				return remoteUrl;
+			}
+		}
+
+		return cachedFile.toURI().toString();
+	}
+
+	private static File getCacheDir() {
+		String downloadDir = Util.getDownloadDir();
+		File cacheDir = new File(downloadDir + CACHE_DIR_NAME);
+		if (!cacheDir.exists()) {
+			cacheDir.mkdirs();
+		}
+		return cacheDir;
+	}
+
+	private static boolean downloadToFile(String remoteUrl, File cachedFile) {
+		File tempFile = new File(cachedFile.getAbsolutePath() + ".tmp");
+		try {
+			URLConnection connection = new URL(remoteUrl).openConnection();
+			connection.setConnectTimeout(CONNECT_TIMEOUT_MS);
+			connection.setReadTimeout(READ_TIMEOUT_MS);
+
+			try (InputStream inputStream = connection.getInputStream()) {
+				Files.copy(inputStream, tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+			}
+
+			Files.move(tempFile.toPath(), cachedFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+			return true;
+		} catch (Exception e) {
+			log.debug("Failed to download map image from {}", remoteUrl, e);
+			if (tempFile.exists()) {
+				tempFile.delete();
+			}
+			return false;
+		}
+	}
+
+	private static String hashUrl(String remoteUrl) {
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			byte[] hash = digest.digest(remoteUrl.getBytes(StandardCharsets.UTF_8));
+			StringBuilder hex = new StringBuilder();
+			for (byte value : hash) {
+				String encoded = Integer.toHexString(0xff & value);
+				if (encoded.length() == 1) {
+					hex.append('0');
+				}
+				hex.append(encoded);
+			}
+			return hex.toString();
+		} catch (NoSuchAlgorithmException e) {
+			throw new IllegalStateException("SHA-256 algorithm not available", e);
+		}
+	}
+}

--- a/ShellfireVPN/src/main/resources/de/shellfire/vpn/gui/controller/map.html
+++ b/ShellfireVPN/src/main/resources/de/shellfire/vpn/gui/controller/map.html
@@ -7,13 +7,9 @@
   #map_canvas { height: 100%; background-color: #666970; }
 </style>
 <script type="text/javascript">
-  var mapUrlBase = "https://maps.googleapis.com/maps/api/staticmap?key=AIzaSyCsD5XMR93yD1QspE0wDoXYUY_ENjXTyLo&size=800x600&zoom=3";
-
-  var myStyleDisconnected = "&style=feature:landscape|element:geometry|color:0xf1667f&style=feature:road|visibility:off&style=feature:water|element:geometry|color:0x354b5b&style=feature:administrative|visibility:off";
-  var myStyleConnected = "&style=feature:landscape|element:geometry|color:0x39e88d&style=feature:road|visibility:off&style=feature:water|element:geometry|color:0x354b5b&style=feature:administrative|visibility:off";
-  
   var currentLat = 51;
   var currentLng = 0;
+  var currentMode = "disconnected";
   
   function initialize() {
   
@@ -22,42 +18,22 @@
 	  }, false);
 
     document.getMode = function() {
-        var bgImage = document.getElementById("map_canvas").style.backgroundImage;
-		console.log(document.getElementById("map_canvas").style.backgroundImage);
-        return bgImage.includes("0xf1667f") ? "disconnected" : "connected";
+        return currentMode;
     };
-	
-	
-	document.setDisconnected = function() {
-	    var timestamp = new Date().getTime();
-	    document.getElementById("map_canvas").style.backgroundImage = "url('" + mapUrlBase + "&center=" + currentLat + "," + currentLng + myStyleDisconnected + "&_=" + timestamp + "')";
-		console.log(document.getElementById("map_canvas").style.backgroundImage);
+		
+	document.setMapImage = function(imageUrl, mode, lat, lng) {
+	    if (mode) {
+	    	currentMode = mode;
+	    }
+	    if (lat !== undefined && lng !== undefined) {
+	    	currentLat = lat;
+	    	currentLng = lng;
+	    }
+	    if (imageUrl) {
+	    	document.getElementById("map_canvas").style.backgroundImage = "url('" + imageUrl + "')";
+	    }
 	    return document.getMode();
 	};
-	
-	document.setConnected = function() {
-	    var timestamp = new Date().getTime();
-	    document.getElementById("map_canvas").style.backgroundImage = "url('" + mapUrlBase + "&center=" + currentLat + "," + currentLng + myStyleConnected + "&_=" + timestamp + "')";
-	    console.log(document.getElementById("map_canvas").style.backgroundImage);
-		return document.getMode();
-	};
-	
-	document.setPosition = function(lat, lng) {
-	    currentLat = lat;
-	    currentLng = lng;
-	    var timestamp = new Date().getTime();
-		if (document.getMode() == "connected") {
-			document.getElementById("map_canvas").style.backgroundImage = "url('" + mapUrlBase + "&center=" + lat + "," + lng + myStyleConnected + "&_=" + timestamp + "')";
-		} else {
-			document.getElementById("map_canvas").style.backgroundImage = "url('" + mapUrlBase + "&center=" + lat + "," + lng + myStyleDisconnected + "&_=" + timestamp + "')";
-		}
-		console.log(document.getElementById("map_canvas").style.backgroundImage);
-	    
-  	};
-
-
-    document.setPosition(currentLat, currentLng);
-    document.setDisconnected();
   }
 
   window.onload = initialize;


### PR DESCRIPTION
### Motivation
- JavaFX `WebView`/`WebEngine` can have restricted DOM storage and in-page fetches may fail, so map images must be resilient to those limitations. 
- Persist downloaded static map images across restarts by storing them on disk in the same `servers` download folder used by other server image managers. 
- Move download and caching logic to the Java client to avoid relying on `localStorage` or fragile DOM background-string heuristics. 
- Provide a simple Java→JS hook to set map background images and explicit connection mode instead of inferring it from the DOM. 

### Description
- Added `StaticMapImageCacheManager` which downloads map images to `Util.getDownloadDir() + "servers\"` with SHA-256 hashed filenames, atomic temp-file writes, and configurable timeouts. 
- Updated `AppScreenControllerStatus` to build static Google Map URLs, call `StaticMapImageCacheManager.getCachedMapImageUrl(...)`, and call `webEngine.executeScript("document.setMapImage(...)")` from `updateMapImage` while tracking `currentMapLat`/`currentMapLng` and connection state. 
- Added `escapeForJavaScript` to safely escape file URLs before embedding them in JS calls. 
- Simplified `map.html` to remove in-page caching/fetch/localStorage logic and expose `document.setMapImage(imageUrl, mode, lat, lng)` which simply sets the `#map_canvas` background and tracks mode/coordinates. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69661db6617c8329b94d78e7e460f90d)